### PR TITLE
Flush stdout after logging

### DIFF
--- a/xssproxy.c
+++ b/xssproxy.c
@@ -21,6 +21,7 @@ void vmsg(const char *format, ...)
     va_start(args, format);
     vfprintf(stdout, format, args);
     va_end(args);
+    fflush(stdout);
 }
 
 void disable_screensaver()


### PR DESCRIPTION
When running `xssproxy` through systemd (or anything not directly a terminal), the libc buffers stdout. This means we can't get the immediate output of `xssproxy` in the journal. Flushing stdout fixes this issue.