### PR TITLE
Listen on object path `/org/freedesktop/ScreenSaver` too

### DIFF
--- a/xssproxy.c
+++ b/xssproxy.c
@@ -280,6 +280,11 @@ DBusConnection *dbus_conn_init()
         &vtable, NULL, &err);
     check_and_exit(&err);
 
+    dbus_connection_try_register_object_path(conn,
+        "/org/freedesktop/ScreenSaver",
+        &vtable, NULL, &err);
+    check_and_exit(&err);
+
     return conn;
 }
 


### PR DESCRIPTION
The freedesktop.org spec doesn't mention which object path the methods are supposed to be called on. xssproxy currently listens on `/ScreenSaver`, but Chromium wants the ["conventional"][1] `/org/freedesktop/ScreenSaver` path instead.

There's no reason we can't listen on both, so let's do that.

[1]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus